### PR TITLE
Add optional value to user constructor

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -10,7 +10,7 @@ _JWT_ISSUER = config['SERVER_NAME']
 class EgaUser(flask_login.UserMixin):
     """An EGA user."""
 
-    def __init__(self, ega_id, ega_password):
+    def __init__(self, ega_id, ega_password=None):
         """Construct a user class. It takes id and password as arguments."""
         self.ega_id = ega_id
         self.ega_password = ega_password


### PR DESCRIPTION
The optional password is necessary to load logged in users into the Login Manager.