### PR TITLE
Remove decorators

### DIFF
--- a/backend/ega_blueprint.py
+++ b/backend/ega_blueprint.py
@@ -6,7 +6,6 @@ import logging
 ega_bp = Blueprint("ega", __name__, url_prefix="/ega")
 
 
-@ega_bp.route("/login", methods=['GET', 'POST'])
 def login():
     """Sign in to EGA."""
     if ega_authenticator.is_logged_in():
@@ -24,13 +23,6 @@ def login():
     return render_template('ega_login_form.html', title='EGA login', form=form)
 
 
-@ega_bp.route("/logout")
-def logout():
-    """Sign out from EGA."""
-    return ega_authenticator.logout_from_ega()
-
-
-@ega_bp.route("/login/info")
 def info():
     """Display EGA user info."""
     logged_in_user = ega_authenticator.is_logged_in()
@@ -40,3 +32,13 @@ def info():
                                access_token=logged_in_user.get_jwt_token())
     else:
         return redirect(url_for("index"), 302)
+
+
+def logout():
+    """Sign out from EGA."""
+    return ega_authenticator.logout_from_ega()
+
+
+ega_bp.add_url_rule('/login', 'login', view_func=login, methods=['GET', 'POST'])
+ega_bp.add_url_rule('/info', 'info', view_func=info)
+ega_bp.add_url_rule('/logout', 'logout', view_func=logout)

--- a/backend/route.py
+++ b/backend/route.py
@@ -3,14 +3,12 @@ monkey.patch_all() # noqa
 
 import logging
 import datetime
+import elixir_blueprint
+import ega_blueprint
 from gevent.pywsgi import WSGIServer
 from flask import (
     Flask, render_template
 )
-import elixir_blueprint
-import ega_blueprint
-import elixir_authenticator
-from flask_pyoidc import OIDCAuthentication
 from flask_login import LoginManager
 from settings import SERVICE_SETTINGS as config
 from models import EgaUser
@@ -27,9 +25,6 @@ app.config.update({'SERVER_NAME': config['SERVER_NAME'],
                    'PREFERRED_URL_SCHEME': config['URL_SCHEME'],
                    "SESSION_PERMANENT": True,
                    'DEBUG': True})
-
-# Setup OIDC Authenticator
-authenticator = OIDCAuthentication({'default': elixir_authenticator.PROVIDER_CONFIG}, app)
 
 # Setup EGA Authenticator
 ega_login_manager = LoginManager()


### PR DESCRIPTION
Both authentication components have been refactored to use standard service route addition rules without using decorators.