### PR TITLE
Add GA4GH passport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Parameter | Description | Defined value
 `ELIXIR_USERINFO_URL` | Elixir user info endpoint | `http://localhost:9090/me`
 `ELIXIR_ISSUER_URL` | Elixir issuer URL | `http://localhost:9090`
 `ELIXIR_REVOCATION_URL` | Elixir token revocation endpoint | `http://localhost:9090`
+`ELIXIR_SCOPE` | Elixir OIDC scope. You may choose openid or ga4gh_passport_v1 | `openid`
 `CEGA_AUTH_URL` | CEGA server endpoint | `http://localhost:8443/lega/v1/legas/users/`
 `CEGA_ID` | CEGA server authentication id | `dummy`
 `CEGA_SECRET` | CEGA server authentication secret | `dummy`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Parameter | Description | Defined value
 `ELIXIR_USERINFO_URL` | Elixir user info endpoint | `http://localhost:9090/me`
 `ELIXIR_ISSUER_URL` | Elixir issuer URL | `http://localhost:9090`
 `ELIXIR_REVOCATION_URL` | Elixir token revocation endpoint | `http://localhost:9090`
-`ELIXIR_SCOPE` | Elixir OIDC scope. You may choose openid or ga4gh_passport_v1 | `openid`
+`ELIXIR_SCOPE` | Elixir OIDC scopes, separated by space. You may choose "openid" or "openid ga4gh_passport_v1" | `openid`
 `CEGA_AUTH_URL` | CEGA server endpoint | `http://localhost:8443/lega/v1/legas/users/`
 `CEGA_ID` | CEGA server authentication id | `dummy`
 `CEGA_SECRET` | CEGA server authentication secret | `dummy`

--- a/backend/elixir_authenticator.py
+++ b/backend/elixir_authenticator.py
@@ -2,11 +2,14 @@ from flask_pyoidc.provider_configuration import ProviderConfiguration, ProviderM
 from settings import SERVICE_SETTINGS as config
 import requests
 import flask
+from flask import redirect
 from flask_pyoidc.user_session import UserSession, UninitialisedSession
 from requests.auth import HTTPBasicAuth
 import logging
 from route import app
 from flask_pyoidc import OIDCAuthentication
+from flask_pyoidc import auth_response_handler
+import importlib_resources
 
 
 _CLIENT_ID = config['ELIXIR_ID']
@@ -17,6 +20,7 @@ _JWKS_URL = config['ELIXIR_CERTS_URL']
 _USERINFO_URL = config['ELIXIR_USERINFO_URL']
 _ISSUER_URL = config['ELIXIR_ISSUER_URL']
 _TOKEN_REVOCATION_URL = config['ELIXIR_REVOCATION_URL']
+_ELIXIR_SCOPE = config['ELIXIR_SCOPE']
 
 _CLIENT_METADATA = ClientMetadata(client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET)
 
@@ -27,7 +31,8 @@ _PROVIDER_METADATA = ProviderMetadata(issuer=_ISSUER_URL,
                                       jwks_uri=_JWKS_URL)
 
 PROVIDER_CONFIG = ProviderConfiguration(provider_metadata=_PROVIDER_METADATA,
-                                        client_metadata=_CLIENT_METADATA)
+                                        client_metadata=_CLIENT_METADATA,
+                                        auth_request_params={'scope': _ELIXIR_SCOPE.split()})
 
 oidc_authenticator = OIDCAuthentication({'default': PROVIDER_CONFIG}, app)
 
@@ -36,6 +41,7 @@ def authenticate_with_elixir():
     """Authenticate with Elixir."""
     session = UserSession(flask.session, "default")
     pyoidc_fcd = oidc_authenticator.clients[session.current_provider]
+
     if session.should_refresh(pyoidc_fcd.session_refresh_interval_seconds):
         logging.debug('Refreshing user auth"')
         return oidc_authenticator._authenticate(client=pyoidc_fcd, interactive=False)
@@ -90,4 +96,56 @@ def handle_uninitialised_session():
 
 def handle_auth_response():
     """Handle auth response to get user info."""
-    return oidc_authenticator._handle_authentication_response()
+    has_error = flask.request.args.get('error', False, lambda x: bool(int(x)))
+    if has_error:
+        if 'error' in flask.session:
+            logging.error("Error in flask session")
+            return "Errpr in flask session"
+        logging.error("Auth response could not be handled")
+        return 'Something went wrong.'
+
+    if flask.session.pop('fragment_encoded_response', False):
+        return importlib_resources.read_binary('flask_pyoidc', 'parse_fragment.html').decode('utf-8')
+
+    is_processing_fragment_encoded_response = flask.request.method == 'POST'
+
+    if is_processing_fragment_encoded_response:
+        auth_resp = flask.request.form
+    else:
+        auth_resp = flask.request.args
+
+    client = oidc_authenticator.clients[UserSession(flask.session).current_provider]
+
+    authn_resp = client.parse_authentication_response(auth_resp)
+    logging.debug('Received authentication response: %s', authn_resp.to_json())
+
+    try:
+        result = auth_response_handler.AuthResponseHandler(client).process_auth_response(authn_resp,
+                                                                                         flask.session.pop('state'),
+                                                                                         flask.session.pop('nonce'))
+    except auth_response_handler.AuthResponseErrorResponseError as e:
+        logging.error(e)
+        return 'The authentication response threw an exception'
+    except auth_response_handler.AuthResponseProcessError as e:
+        logging.error(e)
+        return 'The authentication response could not be processed'
+
+    userinfo = result.userinfo_claims
+
+    # Since we cannot store all visas in the session cookie, we pick just one
+    if 'ga4gh_passport_v1' in userinfo:
+        logging.debug('Passport found in userinfo')
+        visa = userinfo['ga4gh_passport_v1'][0]
+        userinfo.pop('ga4gh_passport_v1')
+        userinfo["visa"] = visa
+
+    UserSession(flask.session).update(result.access_token,
+                                      result.id_token_claims,
+                                      result.id_token_jwt,
+                                      userinfo)
+
+    destination = flask.session.pop('destination')
+    if is_processing_fragment_encoded_response:
+        return destination
+
+    return redirect(destination, 302)

--- a/backend/elixir_blueprint.py
+++ b/backend/elixir_blueprint.py
@@ -18,9 +18,9 @@ def info():
     """Display Elixir user info."""
     user_session = elixir_authenticator.handle_uninitialised_session()
     if user_session and user_session.is_authenticated():
-        print(user_session.userinfo)
         return render_template("elixir_login_success.html",
                                user_name=user_session.userinfo['sub'],
+                               visa=user_session.userinfo.get('visa', None),
                                access_token=user_session.access_token)
     else:
         return redirect(url_for("index"), 302)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -24,6 +24,7 @@ SERVICE_SETTINGS = {"LOG_LEVEL": os.environ.get("LOG_LEVEL", yaml_settings.get("
                     "ELIXIR_USERINFO_URL": os.environ.get("ELIXIR_USERINFO_URL", yaml_settings.get("elixir", {}).get("userInfo", "http://localhost:9090/me")),
                     "ELIXIR_ISSUER_URL": os.environ.get("ELIXIR_ISSUER_URL", yaml_settings.get("elixir", {}).get("issuer", "http://localhost:9090")),
                     "ELIXIR_REVOCATION_URL": os.environ.get("ELIXIR_REVOCATION_URL", yaml_settings.get("elixir", {}).get("revocationUrl", "http://localhost:9090")),
+                    "ELIXIR_SCOPE": os.environ.get("ELIXIR_SCOPE", yaml_settings.get("elixir", {}).get("scope", "openid")),
                     "CEGA_AUTH_URL": os.environ.get("CEGA_AUTH_URL", yaml_settings.get("cega", {}).get("authUrl", "http://localhost:8443/lega/v1/legas/users/")),
                     "CEGA_ID": os.environ.get("CEGA_ID", yaml_settings.get("cega", {}).get("id", "dummy")),
                     "CEGA_SECRET": os.environ.get("CEGA_SECRET", yaml_settings.get("cega", {}).get("secret", "dummy")),

--- a/frontend/templates/elixir_login_success.html
+++ b/frontend/templates/elixir_login_success.html
@@ -10,7 +10,13 @@
         <p>
 
         <pre class="border border-secondary rounded py-2 px-3 my-4" style="user-select: all;">{{access_token}}</pre>
+        {% if visa %}
+        <p class="text-center">
+          Your visa is the following:
+        <p>
 
+        <pre class="border border-secondary rounded py-2 px-3 my-4" style="user-select: all;">{{visa}}</pre>
+        {% endif %}
         <a href="{{ url_for('index')}}" class="btn btn-primary btn-block">Continue</a>
         <a href="{{ url_for('elixir.logout')}}" class="btn btn-danger btn-block">Log out</a>
   </div>

--- a/settings-sample.yaml
+++ b/settings-sample.yaml
@@ -10,6 +10,7 @@ elixir:
   userInfo: "http://localhost:9090/me"
   issuer: "http://localhost:9090"
   revocationUrl: "http://localhost:9090"
+  scope: "openid"
 cega:
   authUrl: "http://localhost:8443/lega/v1/legas/users/"
   id: "dummy"


### PR DESCRIPTION
A single passport visa is currently displayed to the user after deploying this service with the custom passport scope.