### PR TITLE
Detect invalid code

### DIFF
--- a/sda_auth/elixir_authenticator.py
+++ b/sda_auth/elixir_authenticator.py
@@ -107,15 +107,13 @@ class ElixirAuthenticator:
         """Send token request."""
         args = {"response_type": 'access_token',
                 "grant_type": 'authorization_code',
-                "code": flask.session['code'],
                 "scope": _ELIXIR_SCOPE.split()}
         htargs = {'timeout': 10}
 
         grant = Grant()
-        grant.code = flask.session['code']
+        grant.code = flask.session.pop("code")
         grant.grant_expiration_time = time_util.utc_time_sans_frac() + 30
         self.client.grant = {flask.session['state']: grant}
-        logging.debug(flask.session.get("code"))
         logging.debug('making token request: %s', args)
         return self.client.do_access_token_request(state=flask.session["state"],
                                                    request_args=args,

--- a/sda_auth/elixir_blueprint.py
+++ b/sda_auth/elixir_blueprint.py
@@ -22,7 +22,13 @@ def login():
         elixir_authenticator.handle_authentication_response()
         tok_req = elixir_authenticator.send_token_request()
         logging.debug("Access token resp")
-        token_resp = elixir_authenticator.handle_token_response(tok_req)
+
+        try:
+            token_resp = elixir_authenticator.handle_token_response(tok_req)
+        except Exception as e:
+            logging.error(e)
+            return redirect(url_for("index"))
+
         userinfo_req = elixir_authenticator.send_userinfo_request(token_resp)
         logging.debug("User info token resp")
         userinfo = elixir_authenticator.handle_userinfo_response(userinfo_req)


### PR DESCRIPTION
Once a code has already been used to retrieve the access token, it should not be used again. This PR pops the code out of the session and handles the situation when the user attempts to reuse an invalid code.