### PR TITLE
Feature/fix hostfile hack

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,8 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
-    - name: Update hosts file
-      run: sudo echo -e "127.0.0.1 oidc\n127.0.0.1 backend" | sudo tee -a /etc/hosts
     - name: Start virtual infrastructure
       run: docker-compose -f ./dev-server/docker-compose.yml up -d --force-recreate --build
     - name: Run unit tests

--- a/dev-server/docker-compose.yml
+++ b/dev-server/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     image: mock-oidc-user-server
     environment:
       - PORT=9090
+      - HOST=oidc
       - CLIENT_ID=XC56EL11xx
       - CLIENT_SECRET=wHPVQaYXmdDHg
       - CLIENT_REDIRECT_URI=http://localhost:31111/elixir/login

--- a/dev-server/docker-compose.yml
+++ b/dev-server/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   oidc:
+    container_name: oidc
     build:
       context: ./oidc
       dockerfile: Dockerfile
@@ -9,10 +10,11 @@ services:
       - PORT=9090
       - CLIENT_ID=XC56EL11xx
       - CLIENT_SECRET=wHPVQaYXmdDHg
-      - CLIENT_REDIRECT_URI=http://backend:31111/elixir/login
+      - CLIENT_REDIRECT_URI=http://localhost:31111/elixir/login
     ports:
       - 9090:9090
   cega:
+    container_name: cega
     image: egarchive/lega-base:release.v0.2.0
     volumes:
       - ./cega-users:/cega
@@ -23,10 +25,14 @@ services:
       - CEGA_USERS_USER=dummy
     ports:
       - 8443:8443
-  backend:
+  auth:
+    container_name: auth
     build:
       context: ../
       dockerfile: Dockerfile
+    environment:
+      - LOG_LEVEL=DEBUG
+      - CONF_FILE_PATH=/sda-auth/settings-sample.yaml
     volumes:
       - ../keys:/keys
       - ../:/sda-auth

--- a/dev-server/oidc/server.js
+++ b/dev-server/oidc/server.js
@@ -3,6 +3,7 @@ const camelCase = require('camelcase');
 const Provider = require('oidc-provider');
 
 const port = process.env.PORT || 3000;
+const host = process.env.HOST || "oidc" ;
 
 const config = ['CLIENT_ID', 'CLIENT_SECRET', 'CLIENT_REDIRECT_URI'].reduce((acc, v) => {
   assert(process.env[v], `${v} config missing`);
@@ -49,7 +50,7 @@ const oidcConfig = {
 
 };
 
-const oidc = new Provider(`http://oidc:${port}`, oidcConfig);
+const oidc = new Provider(`http://${host}:${port}`, oidcConfig);
 
 const clients= [{
     client_id: config.clientId,
@@ -62,7 +63,7 @@ let server;
 await oidc.initialize({ clients });
   server = oidc.listen(port, () => {
     console.log(
-      `mock-oidc-user-server listening on port ${port}, check http://oidc:${port}/.well-known/openid-configuration`
+      `mock-oidc-user-server listening on port ${port}, check http://${host}:${port}/.well-known/openid-configuration`
     );
   });
 })().catch(err => {

--- a/settings-sample.yaml
+++ b/settings-sample.yaml
@@ -1,10 +1,10 @@
 ---
 logLevel: "DEBUG"
 elixir:
-  redirectUri: "http://backend:31111/elixir/login"
+  redirectUri: "http://localhost:31111/elixir/login"
   id: "XC56EL11xx"
   secret: "wHPVQaYXmdDHg"
-  authUrl: "http://oidc:9090/auth"
+  authUrl: "http://localhost:9090/auth"
   tokenUrl: "http://oidc:9090/token"
   certsUrl: "http://oidc:9090/certs"
   userInfo: "http://oidc:9090/me"
@@ -19,7 +19,7 @@ cega:
   jwtSignatureAlg: "ES256"
 bindAddress: "0.0.0.0"
 port: 31111
-serverName: "backend:31111"
+serverName: "localhost:31111"
 urlScheme: "http"
 development: True
 # Generated with os.urandom(24).hex()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -11,7 +11,7 @@ class TestElixirAuth(unittest.TestCase):
 
     def setUp(self):
         """Initialise authenticator."""
-        self.backend_url = "http://backend:31111/elixir/login"
+        self.backend_url = "http://localhost:31111/elixir/login"
 
 
     def tearDown(self):
@@ -46,7 +46,7 @@ class TestElixirAuth(unittest.TestCase):
         self.assertEqual(grant_response.status_code, 302)
         self.assertIsNotNone(grant_id)
 
-        oidc_url = f'http://oidc:9090{location}/submit'
+        oidc_url = f'http://localhost:9090{location}/submit'
         cookies = {"_grant": grant_id}
         creds_payload = {"view":'login',
                          "login":'dummy',
@@ -69,8 +69,8 @@ class TestEGAAuth(unittest.TestCase):
 
     def setUp(self):
         """Initialise authenticator."""
-        self.backend_url = "http://backend:31111/ega/login"
-        self.user_info_url = "http://backend:31111/ega/info"
+        self.backend_url = "http://localhost:31111/ega/login"
+        self.user_info_url = "http://localhost:31111/ega/info"
 
 
     def tearDown(self):


### PR DESCRIPTION
Docker compose sets up a dedicated network for containers deployed in the same file, we can use this for container to container communications using the set container names.

For user related addresses we can use localhost for all connections and thus will not have to add any changes to the users hosts file.