### PR TITLE
Add protocol to token issuer

### DIFF
--- a/sda_auth/models.py
+++ b/sda_auth/models.py
@@ -8,10 +8,10 @@ from sda_auth.settings import SERVICE_SETTINGS as config
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
-
+_PROTOCOL = "https://" if config["ENABLE_TLS"] else "http://"
 _JWT_PRIVATE_KEY = config['JWT_PRIVATE_KEY']
 _JWT_SIGNATURE_ALG = config['JWT_SIGNATURE_ALG']
-_JWT_ISSUER = config['SERVER_NAME']
+_JWT_ISSUER =  _PROTOCOL + config['SERVER_NAME']
 
 
 class EgaUser(flask_login.UserMixin):

--- a/sda_auth/models.py
+++ b/sda_auth/models.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives import serialization
 _PROTOCOL = "https://" if config["ENABLE_TLS"] else "http://"
 _JWT_PRIVATE_KEY = config['JWT_PRIVATE_KEY']
 _JWT_SIGNATURE_ALG = config['JWT_SIGNATURE_ALG']
-_JWT_ISSUER =  _PROTOCOL + config['SERVER_NAME']
+_JWT_ISSUER = _PROTOCOL + config['SERVER_NAME']
 
 
 class EgaUser(flask_login.UserMixin):


### PR DESCRIPTION
The used protocol schema has now been added to the "iss" field of the EGA access token.

Fixes #31 